### PR TITLE
Preserve groups in np()

### DIFF
--- a/R/np.R
+++ b/R/np.R
@@ -10,14 +10,14 @@
 #'
 #' @export
 np <- function(df, x, ...) {
-  count_var <- enquo(x)
-  group_var <- quos(...)
+  quo_x <- enquo(x)
+  grps <- groups(df)
 
   df %>%
-    group_by(!!!group_var) %>%
-    count(!!count_var) %>%
+    group_by(..., add = TRUE) %>%
+    count(!!quo_x) %>%
     mutate(p = n / sum(n), n_ryhma = sum(n)) %>%
-    ungroup()
+    group_by(!!!grps)
 }
 
 #' Create an np table and display it with gt

--- a/tests/testthat/test-np.R
+++ b/tests/testthat/test-np.R
@@ -1,0 +1,11 @@
+context("test-np")
+
+test_that("preserves existing groups", {
+  x <- group_by(mtcars, am)
+  out <- np(x, vs)
+  expect_equal(groups(out), groups(x))
+})
+
+test_that("honours existing groups", {
+  expect_equal(np(group_by(mtcars, am), vs), np(mtcars, vs, am))
+})


### PR DESCRIPTION
If data given as input to `np()` are already grouped, should this grouping be included in the counts and percentage calculation, and also preserved in the output data? This behaviour would be consistent with how `dplyr::count()` works.